### PR TITLE
Use raggedbottom formatting

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -153,7 +153,7 @@
 %% START OF DOCUMENT
 \begin{document}
 % Don't expand text to fill the page.
-\raggedbottom
+\raggedbottom\
 
 \edef\marginnotetextwidth{\the\textwidth}
 


### PR DESCRIPTION
Fixes issue #8 

`footmisc` has the `bottom` option added to keep footnotes at the bottom of the page, otherwise they sit just under the text (which means they are at different heights on most pages).