### PR TITLE
Add latex version notes

### DIFF
--- a/copyright.tex
+++ b/copyright.tex
@@ -4,19 +4,3 @@
 
 This book was originally published in 1988 by Victoria University Press, Victoria University of Wellington and ©John Dawson.
 It was subsequently made available in the New Zealand Electronic Text Collection (\url{https://nzetc.victoria.ac.nz/}) under a CC-BY-SA 3.0 NZ license (\url{https://creativecommons.org/licenses/by-sa/3.0/nz/}).
-
-In 2021 Doug Rinckes converted it to \LaTeX\, with EB Garamond and Biolinum fonts.
-The source is available (under the same CC-BY-SA 3.0 NZ license) at \url{https://github.com/drinckes/forestvinestosnowtussocks}.
-
-Original catalogue information:
-
-\begin{quote}
-	National Library of New Zealand\newline
-	Cataloguing-in-Publication data
-
-	DAWSON, John\newline
-	Forest vines to snow tussocks: the story of New Zealand plants/John Dawson. --- Wellington (N. Z.): Victoria University Press, 1988. --- 1 v.\newline
-	ISBN 0-86473-047-0\newline% chktex 8
-	581.9931\newline
-	1. Botany --- New Zealand. I. Title.\newline
-\end{quote}

--- a/latex-notes.tex
+++ b/latex-notes.tex
@@ -1,0 +1,23 @@
+\chapter{Notes on the \LaTeX\ version}
+
+\emph{Forest Vines To Snow Tussocks} has been sadly out of print for some years.
+Fortunately, Victoria University of Wellington has made it available in their New Zealand Electronic Text Collection (\url{https://nzetc.victoria.ac.nz/}), under a CC-BY-SA 3.0 NZ license (\url{https://creativecommons.org/licenses/by-sa/3.0/nz/}).
+
+In 2021, I, Doug Rinckes, prepared this \LaTeX\ version. The source is available (under the same license) at \url{https://github.com/drinckes/forestvinestosnowtussocks}.
+
+Deviations from the original book are minor, largely limited to correcting errors made in previous conversions.
+
+The book is set in 11pt EB Garamond, with Biolinum for chapter and section headings.
+
+Original catalogue information:
+
+\begin{quote}
+	National Library of New Zealand\newline
+	Cataloguing-in-Publication data
+
+	DAWSON, John\newline
+	Forest vines to snow tussocks: the story of New Zealand plants/John Dawson. --- Wellington (N. Z.): Victoria University Press, 1988. --- 1 v.\newline
+	ISBN 0-86473-047-0\newline% chktex 8
+	581.9931\newline
+	1. Botany --- New Zealand. I. Title.\newline
+\end{quote}

--- a/main.tex
+++ b/main.tex
@@ -196,6 +196,7 @@
 % The back matter contains appendices, bibliographies, indices, glossaries, etc.
 \backmatter%
 \printbibliography[heading=bibintoc]
+\subfile{latex-notes}
 % Set the heading otherwise the previous chapter heading leaks.
 \markboth{Index}{Index}
 \printindex


### PR DESCRIPTION
Moves the information from the copyright page to the end of the book.

Fixes #25 