### PR TITLE
Allow mixed case headers in toc etc

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -198,8 +198,8 @@
 \cleardoublepage%
 \renewcommand{\baselinestretch}{0.5}\normalsize%
 { % Dirty hack to prevent the toc uppercasing its header.
-	  \renewcommand{\MakeUppercase}[1]{#1}
-	  \tableofcontents
+	\renewcommand{\MakeUppercase}[1]{#1}
+	\tableofcontents
 }
 \renewcommand{\baselinestretch}{1.0}\normalsize%
 \cleardoublepage%
@@ -222,15 +222,14 @@
 
 % The back matter contains appendices, bibliographies, indices, glossaries, etc.
 \backmatter%
-\printbibliography[heading=bibintoc]
 { % Dirty hack to prevent the bibliography uppercasing its header.
-	  \renewcommand{\MakeUppercase}[1]{#1}
-	  \renewcommand{\bibname}{References}
-	  \tableofcontents
+	\renewcommand{\MakeUppercase}[1]{#1}
+	\renewcommand{\bibname}{References}
+	\printbibliography[heading=bibintoc]
 }
 { % Dirty hack to prevent the index uppercasing its header.
-	  \renewcommand{\MakeUppercase}[1]{#1}
-	  \printindex
+	\renewcommand{\MakeUppercase}[1]{#1}
+	\printindex
 }
 \cleardoublepage%
 \end{document}

--- a/main.tex
+++ b/main.tex
@@ -197,7 +197,10 @@
 \subfile{copyright}
 \cleardoublepage%
 \renewcommand{\baselinestretch}{0.5}\normalsize%
-\tableofcontents
+{ % Dirty hack to prevent the toc uppercasing its header.
+	  \renewcommand{\MakeUppercase}[1]{#1}
+	  \tableofcontents
+}
 \renewcommand{\baselinestretch}{1.0}\normalsize%
 \cleardoublepage%
 
@@ -220,8 +223,14 @@
 % The back matter contains appendices, bibliographies, indices, glossaries, etc.
 \backmatter%
 \printbibliography[heading=bibintoc]
-% Set the heading otherwise the previous chapter heading leaks.
-\markboth{Index}{Index}
-\printindex
-
+{ % Dirty hack to prevent the bibliography uppercasing its header.
+	  \renewcommand{\MakeUppercase}[1]{#1}
+	  \renewcommand{\bibname}{References}
+	  \tableofcontents
+}
+{ % Dirty hack to prevent the index uppercasing its header.
+	  \renewcommand{\MakeUppercase}[1]{#1}
+	  \printindex
+}
+\cleardoublepage%
 \end{document}


### PR DESCRIPTION
Override the `\MakeUpperCase` command to prevent table of contents, bibliography, and index from uppercasing their titles.

Annoyingly this is done before throwing them into the header, so it can't be fixed by the `fancyhdr` package.

fixes #46 